### PR TITLE
Fix unvendorable [%blob] path

### DIFF
--- a/cli/main.ml
+++ b/cli/main.ml
@@ -69,7 +69,7 @@ let cmd_jsoo =
   in
   let emit_js_dep filename =
     let close, h = if filename = "" then false, stdout else true, open_out filename in
-    output_string h [%blob "jsoo/sherlodoc.js"] ;
+    output_string h [%blob "../jsoo/sherlodoc.js"] ;
     if close then close_out h
   in
   Cmd.v info Term.(const emit_js_dep $ target)

--- a/index/index.ml
+++ b/index/index.ml
@@ -21,7 +21,7 @@ let index_odoc_index_file register filename =
   | Error (`Msg msg) -> Format.printf "FILE ERROR %s: %s@." filename msg
   | Ok file ->
     (match Odoc_odoc.Odoc_file.load_index file with
-     | Ok entries -> Odoc_model.Paths.Identifier.Hashtbl.Any.iter register (snd entries)
+     | Ok entries -> Odoc_model.Paths.Identifier.Hashtbl.Any.iter register entries.index
      | Error (`Msg msg) -> Format.printf "Odoc warning or error %s: %s@." filename msg)
 
 let main


### PR DESCRIPTION
The path relative to the project root makes sherlodoc impossible to vendor. Use a relative path instead.